### PR TITLE
Fix access specifier issue causing build failure

### DIFF
--- a/Classes/Source.swift
+++ b/Classes/Source.swift
@@ -20,7 +20,7 @@ public class Source: NSObject {
         closure(self)
     }
     
-    var didMoveRow: ((NSIndexPath, NSIndexPath) -> Void)?
+    public var didMoveRow: ((NSIndexPath, NSIndexPath) -> Void)?
     
     public func addSection(section: SectionType) -> Self {
         sections.append(section)


### PR DESCRIPTION
`didMoveRow` property in `Source` is unavailable from other modules, because it has default access specifier. Made it public.
