### PR TITLE
add public access control to init method of Row class.

### DIFF
--- a/Classes/Row.swift
+++ b/Classes/Row.swift
@@ -14,7 +14,7 @@ public class Row<T: UITableViewCell>: RowType {
     
     public init() { }
     
-    init(@noescape closure: (Row<T> -> Void)) {
+    public init(@noescape closure: (Row<T> -> Void)) {
         closure(self)
     }
     

--- a/Classes/Row.swift
+++ b/Classes/Row.swift
@@ -12,7 +12,7 @@ public class Row<T: UITableViewCell>: RowType {
     public typealias RowInformation = (row: Row<T>, tableView: UITableView, indexPath: NSIndexPath)
     public typealias RowMoveInformation = (row: Row<T>, tableView: UITableView, sourceIndexPath: NSIndexPath, destinationIndexPath: NSIndexPath)
     
-    init() { }
+    public init() { }
     
     init(@noescape closure: (Row<T> -> Void)) {
         closure(self)


### PR DESCRIPTION
In order to have a designated initializer in a subclass of Row class, I'd like to add ’public’ access control to init() method of Row class. 
