### PR TITLE
Add: check permit index path

### DIFF
--- a/Classes/Source.swift
+++ b/Classes/Source.swift
@@ -22,6 +22,10 @@ public class Source: NSObject {
     
     public var didMoveRow: ((NSIndexPath, NSIndexPath) -> Void)?
     
+    func isPermitIndexPath(indexPath: NSIndexPath) -> Bool {
+        return sections.count > indexPath.section && sections[indexPath.section].rows.count > indexPath.row
+    }
+    
     public func addSection(section: SectionType) -> Self {
         sections.append(section)
         return self
@@ -200,6 +204,9 @@ extension Source: UITableViewDelegate {
     }
     
     public func tableView(tableView: UITableView, didEndDisplayingCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
+        if !isPermitIndexPath(indexPath) {
+            return
+        }
         let row = sectionFor(indexPath).rowFor(indexPath) as? RowDelegateType
         row?.didEndDisplayCell(tableView, cell: cell, indexPath: indexPath)
     }

--- a/ShoyuTests/SourceTests.swift
+++ b/ShoyuTests/SourceTests.swift
@@ -120,6 +120,23 @@ class SourceTests: XCTestCase {
         XCTAssertEqual(source.sectionFor(destinationIndexPath).rowFor(destinationIndexPath).reuseIdentifier, reuserIdentifierFromIndexPath(sourceIndexPath))
     }
     
+    func testPermitIndexPath() {
+        let rowLimit = UInt(10)
+        let sectionLimit = UInt(10)
+        
+        let source = Source() { source in
+            source.createSections(sectionLimit) { _, section in
+                section.createRows(rowLimit) { _ in }
+            }
+        }
+        
+        let notFailIndexPath = NSIndexPath(forRow: Int(rowLimit - 1), inSection: Int(sectionLimit - 1))
+        XCTAssertTrue(source.isPermitIndexPath(notFailIndexPath))
+        
+        let failIndexPath = NSIndexPath(forRow: Int(rowLimit), inSection: Int(sectionLimit))
+        XCTAssertFalse(source.isPermitIndexPath(failIndexPath))
+    }
+    
     func testBenchmarkSource() {
         class HeaderView: UIView { }
         class FooterView: UIView { }


### PR DESCRIPTION
## Why

I get out of bounds from `Shoyu.Section func rowFor(row: Int)` via `UITableViewDelegate.didEndDisplayCell`. 
I faced this problem when I write that swift logic.

```
    class AnyTableViewController: UITableViewController {

        var elements: Element = // Elements ...

        func setupShoyu() {
        tableView.source = Source().createSection { section in
            section.createRows(elements) { row in
                ...
            }
        }



        func deleteElement(element: Element) { 
            elements.removeFrom(element) 
            setupShoyu() // Reset source.
            tableView.reloadData()  // Get out of bounds from this statement.
        }
    }
```

I thought `removeElement` and `reset source` then disappear corresponded cell.
But Shoyu.Section.rows.count is less than the past.
When get Shoyu.Section.row[indexPath.row], it would fall down.
## What

I add `Shoyu.Source.isPermitIndexPath` function.
This function is check indexPath when didEndDisplayCell.
If not permit indexPath when early stage return.
