### PR TITLE
Fix crash on update in background

### DIFF
--- a/Classes/Row.swift
+++ b/Classes/Row.swift
@@ -91,10 +91,12 @@ extension Row: RowDelegateType {
     }
     
     func didEndDisplayCell(tableView: UITableView, cell: UITableViewCell, indexPath: NSIndexPath) {
-        guard let genericCell = cell as? T else {
-            fatalError()
-        }
-        didEndDisplayCell?(genericCell, (self, tableView, indexPath))
+		if let didEndDisplayCell = didEndDisplayCell {
+			guard let genericCell = cell as? T else {
+				fatalError()
+			}
+			didEndDisplayCell(genericCell, (self, tableView, indexPath))
+		}
     }
     
     func willRemove(tableView: UITableView, indexPath: NSIndexPath) -> UITableViewRowAnimation {

--- a/Classes/Source.swift
+++ b/Classes/Source.swift
@@ -51,7 +51,10 @@ public class Source: NSObject {
     public func createSections<H, F>(count: UInt, @noescape closure: ((UInt, Section<H, F>) -> Void)) -> Self {
         return createSections([UInt](0..<count), closure: closure)
     }
-    
+    	
+	public func deleteSection(section: Int) {
+		sections.removeAtIndex(section)
+	}
 }
 
 public extension Source {


### PR DESCRIPTION
Without this, `Row` would crash during `didEndDisplayCell` handling if table view is not on active controller (for example if there's modal controller on top of table view controller).

The solution here is to simply ignore the call if `didEndDisplayCell` block is not assigned on `Row`. This preserves existing functionality for cases where block is used but prevents the crash otherwise.

Besided crash fix, I also added ability to delete section from source.
